### PR TITLE
Stop publishing docker log covering all services

### DIFF
--- a/src/uk/gov/hmcts/cmc/integrationtests/IntegrationTests.groovy
+++ b/src/uk/gov/hmcts/cmc/integrationtests/IntegrationTests.groovy
@@ -125,7 +125,6 @@ class IntegrationTests implements Serializable {
   private void archiveDockerLogs() {
     steps.sh """
              mkdir -p output
-             ${dockerComposeCommand()} logs --no-color > output/docker-logs.txt
              for service in \$(docker-compose config --services); do docker-compose logs --no-color \$service > output/docker-log-\$service.txt; done
              """
 


### PR DESCRIPTION
### JIRA link ###

None

### Change description ###

It takes ups to 30 seconds to dump the log file. Then it happens again to create log files per service which takes roughly another 30 seconds. To save some time and based on the fact that nobody probably uses log file covering all services this change remove it.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```