### PR TITLE
Align AAT environment variable names

### DIFF
--- a/src/uk/gov/hmcts/cmc/integrationtests/IntegrationTests.groovy
+++ b/src/uk/gov/hmcts/cmc/integrationtests/IntegrationTests.groovy
@@ -33,17 +33,17 @@ class IntegrationTests implements Serializable {
     ],
     [$class: 'VaultSecret', path: 'secret/dev/cmc/smoke-tests/citizen-username', secretValues:
       [
-        [$class: 'VaultSecretValue', envVar: 'SMOKE_TEST_CITIZEN_USERNAME', vaultKey: 'value']
+        [$class: 'VaultSecretValue', envVar: 'AAT_TEST_CITIZEN_USER_USERNAME', vaultKey: 'value']
       ]
     ],
     [$class: 'VaultSecret', path: 'secret/dev/cmc/smoke-tests/solicitor-username', secretValues:
       [
-        [$class: 'VaultSecretValue', envVar: 'SMOKE_TEST_SOLICITOR_USERNAME', vaultKey: 'value']
+        [$class: 'VaultSecretValue', envVar: 'AAT_TEST_SOLICITOR_USER_USERNAME', vaultKey: 'value']
       ]
     ],
     [$class: 'VaultSecret', path: 'secret/dev/cmc/smoke-tests/password', secretValues:
       [
-        [$class: 'VaultSecretValue', envVar: 'SMOKE_TEST_PASSWORD', vaultKey: 'value']
+        [$class: 'VaultSecretValue', envVar: 'AAT_TEST_USER_PASSWORD', vaultKey: 'value']
       ]
     ]
   ]


### PR DESCRIPTION
### Change description ###

Aligns environment variable names used for AAT smoke and functional testing:

- `AAT_TEST_CITIZEN_USER_USERNAME`
- `AAT_TEST_SOLICITOR_USER_USERNAME`
- `AAT_TEST_USER_PASSWORD` (both above users will re-use the same password until a need arises to do otherwise)

**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```

